### PR TITLE
Updated readme with documentation on build and run basics for future contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,19 @@ Subler is an Mac OS X app created to mux and tag mp4 files. The main features in
 * Mux video, audio, chapters, subtitles and closed captions tracks from mov, mp4 and mkv.
 * Raw formats: H.264 Elementary streams (.h264, .264), AAC (.aac), AC3 (.ac3), Scenarist (.scc), VobSub? (.idx).
 * metadata editing and TMDb, TVDB and iTunes Store support.
+
+### Build and run
+
+Clone the repository and include all submodules
+```
+git clone --recurse-submodules https://github.com/SublerApp/Subler.git
+```
+If you already cloned without submodules and need to add the submodules manually, `cd` into the `./Subler` directory and clone the dependency submodules with 
+```
+git submodule update --init --recursive
+```
+Open `Subler.xcodeproj` in XCode
+
+Build and run the project by selecting the 'Subler' scheme (`Product` -> `Scheme` -> `Subler`) and clicking the 'Run' button in Xcode’s toolbar.
+
+


### PR DESCRIPTION
As someone new to Xcode/Swift development, I initially found the process of handling git submodules and setting up the project unclear. To help future contributors who might face similar challenges, I’ve added a “Build and Run” section to the README.

This section provides instructions for cloning the repository, managing submodules, and building the project in Xcode. The goal is to streamline the onboarding process and help contributors get the project running quickly.

I hope this addition improves the documentation and benefits others who are new to the project or ecosystem.