### PR TITLE
Added ability to set imported multichannel AAC track to Passthru + AAC

### DIFF
--- a/Classes/FileImportController.swift
+++ b/Classes/FileImportController.swift
@@ -115,6 +115,17 @@ final class FileImportController: ViewController, NSTableViewDataSource, NSTable
                                                   enabled: true)
                     actions.append(conversionAction)
                 }
+
+                let audioTrack = track as! MP42AudioTrack
+                let channelCount = audioTrack.channels
+                
+                if track.format == kMP42AudioCodecType_MPEG4AAC && channelCount > 2 {
+                    let conversionAction = Action(title: NSLocalizedString("AAC + Passthru", comment: "File Import action menu item."),
+                                                tag: 6,
+                                                enabled: true)
+                    actions.append(conversionAction)
+                }
+                
             default:
                 break
             }


### PR DESCRIPTION
Currently, if you import a file with an AAC multichannel track, you do not have the ability to passthrough the multichannel plus encoding a downmixed AAC track, like you do if importing a multichannel DTS or AC3 track.
![Screenshot 2024-11-23 at 9 52 04 PM](https://github.com/user-attachments/assets/ea683ab9-66f5-4b3d-b932-8120990307e3)

This PR adds the ability to passthru a multichannel AAC track while encoding a downmixed version.
![Screenshot 2024-11-23 at 9 51 56 PM](https://github.com/user-attachments/assets/474c0525-7ad2-48cd-8c85-f7ed9ccf35cf)

The end result is an mp4 file with a new downmixed AAC track.
![image](https://github.com/user-attachments/assets/a4dd94f1-8afd-4367-a122-31edd77cd853)

