### PR TITLE
Update AppleTV.swift

### DIFF
--- a/Classes/MetadataImporters/AppleTV.swift
+++ b/Classes/MetadataImporters/AppleTV.swift
@@ -130,7 +130,7 @@ public struct AppleTV: MetadataService {
     private let detailsURL = "https://uts-api.itunes.apple.com/uts/v2/view/product/"
     private let episodesURL = "https://uts-api.itunes.apple.com/uts/v2/view/show/"
     private let seasonsURL = "https://uts-api.itunes.apple.com/uts/v2/show/"
-    private let options = "&utsk=0&caller=wta&v=58&pfm=desktop"
+    private let options = "&utsk=0&caller=wta&v=58&pfm=appletv"
 
     private func normalize(_ term: String) -> String {
         return term.replacingOccurrences(of: " (Dubbed)", with: "")


### PR DESCRIPTION
Fix the issue where Apple TV metadata isn't returned for TV/Movies that Apple doesn't currently sell in the given region.
This was a single-line change. I am not a swift developer, I just know APIs very well. Have mercy. Maybe I'll learn swift some day, and provide a change to use the v3 API.

The root of the issue is in how the Apple Media Kit API is being called, and the client's device identification. The existing code was clearly reverse-engineered from a web browser, where the `device=web`. This returns results that are basically Apple TV+ and the Apple Store. Anything that Apple doesn't sell, won't be returned. You can check this behavior on the web and with the API by searching for something that Apple doesn't sell, like a NetFlix original, say 'Red Notice'.

Instead, the API client can identify itself as an Apple TV device, with `device=appletv`. This will provide the search results seen on the Apple TV devices, which includes TV/Movies that Apple does not carry, but they are aware of, and know what partner streaming service has it. Searching for 'Red Notice' this way, returns a result for the actual NetFlix movie. Once you have the show/movie ID, you can use the other endpoints as normal to get more detailed information.

This does not solve for media that Apple is not aware of, or is not streaming _anywhere_ in the given region. Examples of this include 'The Basketball Diaries' and 'Dogma' (at least at the time of writing). They aren't available, anywhere, for streaming. So there is no entry in Apple Media Kit for these (at least not yet discoverable)