### PR TITLE
Added Check-Only-Selected Item

### DIFF
--- a/Base.lproj/FileImportController.xib
+++ b/Base.lproj/FileImportController.xib
@@ -36,6 +36,12 @@
                         <action selector="checkOnlyTracksWithSameLanguage:" target="-2" id="3Gg-ed-oeo"/>
                     </connections>
                 </menuItem>
+                <menuItem title="Check only selected tracks" id="KMR-fY-lFl">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="checkOnlySelectedTracks:" target="-2" id="6Fc-pF-u5c"/>
+                    </connections>
+                </menuItem>
             </items>
             <point key="canvasLocation" x="139" y="146"/>
         </menu>

--- a/Base.lproj/FileImportController.xib
+++ b/Base.lproj/FileImportController.xib
@@ -42,6 +42,13 @@
                         <action selector="checkOnlySelectedTracks:" target="-2" id="6Fc-pF-u5c"/>
                     </connections>
                 </menuItem>
+                <menuItem isSeparatorItem="YES" id="ysZ-lN-Giu"/>
+                <menuItem title="Uncheck All" id="hgt-xJ-ZhD">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="uncheckAllTracks:" target="-2" id="e3T-C5-VtQ"/>
+                    </connections>
+                </menuItem>
             </items>
             <point key="canvasLocation" x="139" y="146"/>
         </menu>

--- a/Classes/FileImportController.swift
+++ b/Classes/FileImportController.swift
@@ -260,7 +260,8 @@ final class FileImportController: ViewController, NSTableViewDataSource, NSTable
         if let action = item.action,
             action == #selector(self.checkSelected(_:)) ||
             action == #selector(self.uncheckSelected(_:)) ||
-            action == #selector(self.checkOnlyTracksWithSameLanguage(_:)) {
+            action == #selector(self.checkOnlyTracksWithSameLanguage(_:)) ||
+			action == #selector(self.checkOnlySelectedTracks(_:)) {
             if tracksTableView.selectedRow != -1 || tracksTableView.clickedRow != -1 {
                 return true
             }
@@ -288,6 +289,23 @@ final class FileImportController: ViewController, NSTableViewDataSource, NSTable
         }
 
         settings.forEach { $0.checked = $0.importable && languages.contains($0.track.language) }
+        reloadCheckColumn(forRowIndexes: IndexSet(integersIn: items.indices))
+    }
+	
+	@IBAction func checkOnlySelectedTracks(_ sender: Any) {
+		let targetedIndices = tracksTableView.targetedRowIndexes;
+		var selectedIndices = tracksTableView.selectedRowIndexes;
+		if (!selectedIndices.contains(targetedIndices.first!))
+		{
+			// This is a shortcut for quickly selecting specific rows.
+			// If the rows are selected and right-clicked, the target is within the selection.
+			// If the user didn't both first selecting rows, use the target index (visible with a selection-border in the UI).
+			// If the user did select but targets another row, use the target row
+			// because if it was intentional, only the targeted row is selected
+			// and if it was not intentional, it's easy to fix and open the menu on top of an actual selected row.
+			selectedIndices = targetedIndices;
+		}
+		settings.enumerated().forEach { (index, item) in item.checked = selectedIndices.contains(index + 1) }
         reloadCheckColumn(forRowIndexes: IndexSet(integersIn: items.indices))
     }
     

--- a/Classes/FileImportController.swift
+++ b/Classes/FileImportController.swift
@@ -261,7 +261,8 @@ final class FileImportController: ViewController, NSTableViewDataSource, NSTable
             action == #selector(self.checkSelected(_:)) ||
             action == #selector(self.uncheckSelected(_:)) ||
             action == #selector(self.checkOnlyTracksWithSameLanguage(_:)) ||
-			action == #selector(self.checkOnlySelectedTracks(_:)) {
+			action == #selector(self.checkOnlySelectedTracks(_:)) ||
+			action == #selector(self.uncheckAllTracks(_:)) {
             if tracksTableView.selectedRow != -1 || tracksTableView.clickedRow != -1 {
                 return true
             }
@@ -306,9 +307,14 @@ final class FileImportController: ViewController, NSTableViewDataSource, NSTable
 			selectedIndices = targetedIndices;
 		}
 		settings.enumerated().forEach { (index, item) in item.checked = selectedIndices.contains(index + 1) }
-        reloadCheckColumn(forRowIndexes: IndexSet(integersIn: items.indices))
-    }
-    
+		reloadCheckColumn(forRowIndexes: IndexSet(integersIn: items.indices))
+	}
+	
+	@IBAction func uncheckAllTracks(_ sender: Any) {
+		settings.enumerated().forEach { (index, item) in item.checked = false }
+		reloadCheckColumn(forRowIndexes: IndexSet(integersIn: items.indices))
+	}
+	
     // MARK: IBActions
     
     @IBAction func closeWindow(_ sender: Any) {


### PR DESCRIPTION
** How was it Changed? **
- importing media to a video, a dialog appears with the tracks to be imported. All tracks are enabled
- there is already a context-menu-item to only check the selected language
- i added another item to the context menu to only check the selected tracks
- the logic is simple:
   - if nothing is selected, the target item is the only checked item
   - if there's selection, these items will then be checked
   - target-item has precedence from selected items because it's more precise but can also be fixed by reopening the menu by targeting the selection

** Why was it changed? **
- i often encounter videos that have all required languages and after conversion but they lack the forced subtitle track
- dragging the source media on the video will open a dialog and tons of subtitle tracks are all selected
- even choosing the "check selected language" item would still select multiple tracks, most of which would need to be deselected in a second step