### PR TITLE
Fix Season localization case to include number placeholder

### DIFF
--- a/Classes/MetadataImporters/MetadataResult.swift
+++ b/Classes/MetadataImporters/MetadataResult.swift
@@ -199,7 +199,7 @@ public final class MetadataResult {
         case diskNumber         = "{Disk #}"
         case episodeNumber      = "{Episode #}"
         case episodeID          = "{Episode ID}"
-        case season             = "{Season}"
+        case season             = "{Season #}"
         case network            = "{Network}"
 
         // Services internal IDs


### PR DESCRIPTION
The `season` case in `MetadataResult.swift` was mapping to `"{Season}"`, missing the number placeholder `#`. This caused the UI to display incomplete localized strings for season numbers.

This updates the mapping to `"{Season #}"` for consistency with the MP42Foundation fix.

Depends on: https://github.com/SublerApp/MP42Foundation/pull/3

See attached screenshots for the issue before the fix:

<img width="721" height="450" alt="Captura de pantalla 2026-07-24 a la(s) 03 59 19" src="https://github.com/user-attachments/assets/64d81310-9973-4be7-827b-3333a1b0158f" />
<img width="772" height="739" alt="Captura de pantalla 2026-07-24 a la(s) 03 59 43" src="https://github.com/user-attachments/assets/1227e9fa-1542-496c-96a0-a5711b6ee715" />
