### PR TITLE
Use .standard for portrait images in TheTVDB

### DIFF
--- a/Classes/MetadataImporters/TheTVDB.swift
+++ b/Classes/MetadataImporters/TheTVDB.swift
@@ -148,8 +148,8 @@ public struct TheTVDB : MetadataService {
                 size = .square
             case (let width, let height) where width >= height:
                 size = .rectangle
-            case (let width, let height) where height < width:
-                size = .default
+            case (let width, let height) where height > width:
+                size = .standard
             default:
                 break
             }
@@ -196,8 +196,8 @@ public struct TheTVDB : MetadataService {
                 size = .square
             case (let width, let height) where width >= height:
                 size = .rectangle
-            case (let width, let height) where height < width:
-                size = .default
+            case (let width, let height) where height > width:
+                size = .standard
             default:
                 break
             }


### PR DESCRIPTION
# Purpose/Changes
In 1.9.1, setting art to `Poster - Standard` for TVDB resulted in vertical posters (as expected). In 1.9.2, the API change broke that. TVDB was fetching horizontal artwork.

This PR sets the standard in TVDB to be `width > height`, which matches AppleTV artwork logic.
